### PR TITLE
Use typeless void* for structs in exported interface functions, see #73

### DIFF
--- a/Modelica/ExternalMedia/Media/BaseClasses/ExternalTwoPhaseMedium.mo
+++ b/Modelica/ExternalMedia/Media/BaseClasses/ExternalTwoPhaseMedium.mo
@@ -224,7 +224,7 @@ package ExternalTwoPhaseMedium "Generic external two phase medium package"
     #include \"externalmedialib.h\"
     #include \"ModelicaUtilities.h\"
     
-    void TwoPhaseMedium_setState_ph_C_impl_wrap(double p, double h, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName)
+    void TwoPhaseMedium_setState_ph_C_impl_wrap(double p, double h, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName)
     {
       TwoPhaseMedium_setState_ph_C_impl_err(p, h, phase, state, mediumName, libraryName, substanceName, ModelicaError,ModelicaWarning);
     }
@@ -248,7 +248,7 @@ package ExternalTwoPhaseMedium "Generic external two phase medium package"
     #include \"externalmedialib.h\"
     #include \"ModelicaUtilities.h\"
     
-    void TwoPhaseMedium_setState_pT_C_impl_wrap(double p, double T, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName)
+    void TwoPhaseMedium_setState_pT_C_impl_wrap(double p, double T, void *state, const char *mediumName, const char *libraryName, const char *substanceName)
     {
       TwoPhaseMedium_setState_pT_C_impl_err(p, T, state, mediumName, libraryName, substanceName, ModelicaError, ModelicaWarning);
     }
@@ -285,7 +285,7 @@ package ExternalTwoPhaseMedium "Generic external two phase medium package"
     #include \"externalmedialib.h\"
     #include \"ModelicaUtilities.h\"
     
-    void TwoPhaseMedium_setState_dT_C_impl_wrap(double d, double T, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName)
+    void TwoPhaseMedium_setState_dT_C_impl_wrap(double d, double T, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName)
     {
       TwoPhaseMedium_setState_dT_C_impl_err(d, T, phase, state, mediumName, libraryName, substanceName, &ModelicaError, &ModelicaWarning);
     }
@@ -309,7 +309,7 @@ package ExternalTwoPhaseMedium "Generic external two phase medium package"
     #include \"externalmedialib.h\"
     #include \"ModelicaUtilities.h\"
     
-    void TwoPhaseMedium_setState_ps_C_impl_wrap(double p, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName)
+    void TwoPhaseMedium_setState_ps_C_impl_wrap(double p, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName)
     {
       TwoPhaseMedium_setState_ps_C_impl_err(p, s, phase, state, mediumName, libraryName, substanceName, &ModelicaError, &ModelicaWarning);
     }
@@ -333,7 +333,7 @@ package ExternalTwoPhaseMedium "Generic external two phase medium package"
     #include \"externalmedialib.h\"
     #include \"ModelicaUtilities.h\"
     
-    void TwoPhaseMedium_setState_hs_C_impl_wrap(double h, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName)
+    void TwoPhaseMedium_setState_hs_C_impl_wrap(double h, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName)
     {
       TwoPhaseMedium_setState_hs_C_impl_err(h, s, phase, state, mediumName, libraryName, substanceName, &ModelicaError, &ModelicaWarning);
     }

--- a/Projects/Sources/externalmedialib.cpp
+++ b/Projects/Sources/externalmedialib.cpp
@@ -63,15 +63,15 @@ double TwoPhaseMedium_getCriticalMolarVolume_C_impl(const char *mediumName, cons
   @param p Pressure
   @param h Specific enthalpy
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setState_ph_C_impl(double p, double h, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setState_ph_C_impl(double p, double h, int phase, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setState_ph(p, h, phase, state);
+    solver->setState_ph(p, h, phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute properties from p and T
@@ -81,15 +81,15 @@ void TwoPhaseMedium_setState_ph_C_impl(double p, double h, int phase, ExternalTh
   Attention: The phase input is ignored for this function!
   @param p Pressure
   @param T Temperature
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setState_pT_C_impl(double p, double T, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setState_pT_C_impl(double p, double T, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setState_pT(p, T, state);
+    solver->setState_pT(p, T, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute properties from d, T, and phase
@@ -98,15 +98,15 @@ void TwoPhaseMedium_setState_pT_C_impl(double p, double T, ExternalThermodynamic
   @param d Density
   @param T Temperature
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setState_dT_C_impl(double d, double T, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setState_dT_C_impl(double d, double T, int phase, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setState_dT(d, T, phase, state);
+    solver->setState_dT(d, T, phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute properties from p, s, and phase
@@ -115,15 +115,15 @@ void TwoPhaseMedium_setState_dT_C_impl(double d, double T, int phase, ExternalTh
   @param p Pressure
   @param s Specific entropy
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setState_ps_C_impl(double p, double s, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setState_ps_C_impl(double p, double s, int phase, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setState_ps(p, s, phase, state);
+    solver->setState_ps(p, s, phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute properties from h, s, and phase
@@ -132,15 +132,15 @@ void TwoPhaseMedium_setState_ps_C_impl(double p, double s, int phase, ExternalTh
   @param h Specific enthalpy
   @param s Specific entropy
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setState_hs_C_impl(double h, double s, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setState_hs_C_impl(double h, double s, int phase, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setState_hs(h, s, phase, state);
+    solver->setState_hs(h, s, phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute partial derivative from a populated state record
@@ -155,9 +155,9 @@ void TwoPhaseMedium_setState_hs_C_impl(double h, double s, int phase, ExternalTh
   @param substanceName Substance name
 */
 double TwoPhaseMedium_partialDeriv_state_C_impl(const char *of, const char *wrt, const char *cst,
-		ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName){
+		void *state, const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->partialDeriv_state(of, wrt, cst, state);
+    return solver->partialDeriv_state(of, wrt, cst, static_cast<ExternalThermodynamicState*>(state));
 }
 
 
@@ -165,160 +165,160 @@ double TwoPhaseMedium_partialDeriv_state_C_impl(const char *of, const char *wrt,
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_prandtlNumber_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_prandtlNumber_C_impl(void *state,
 									 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->Pr(state);
+    return solver->Pr(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return temperature of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_temperature_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_temperature_C_impl(void *state,
 								   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->T(state);
+    return solver->T(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return velocity of sound of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_velocityOfSound_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_velocityOfSound_C_impl(void *state,
 									   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->a(state);
+    return solver->a(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return isobaric expansion coefficient of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_isobaricExpansionCoefficient_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_isobaricExpansionCoefficient_C_impl(void *state,
 													const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->beta(state);
+    return solver->beta(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return specific heat capacity cp of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_specificHeatCapacityCp_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_specificHeatCapacityCp_C_impl(void *state,
 											  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->cp(state);
+    return solver->cp(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return specific heat capacity cv of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_specificHeatCapacityCv_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_specificHeatCapacityCv_C_impl(void *state,
 											  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->cv(state);
+    return solver->cv(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return density of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_density_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_density_C_impl(void *state,
 							   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->d(state);
+    return solver->d(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return derivative of density wrt specific enthalpy at constant pressure of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_density_derh_p_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_density_derh_p_C_impl(void *state,
 									  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->ddhp(state);
+    return solver->ddhp(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return derivative of density wrt pressure at constant specific enthalpy of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_density_derp_h_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_density_derp_h_C_impl(void *state,
 									  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->ddph(state);
+    return solver->ddph(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return dynamic viscosity of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dynamicViscosity_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_dynamicViscosity_C_impl(void *state,
 										const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->eta(state);
+    return solver->eta(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return specific enthalpy of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_specificEnthalpy_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_specificEnthalpy_C_impl(void *state,
 										const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->h(state);
+    return solver->h(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return isothermal compressibility of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_isothermalCompressibility_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_isothermalCompressibility_C_impl(void *state,
 												 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->kappa(state);
+    return solver->kappa(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return thermal conductivity of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_thermalConductivity_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_thermalConductivity_C_impl(void *state,
 										   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->lambda(state);
+    return solver->lambda(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return pressure of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_pressure_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_pressure_C_impl(void *state,
 								const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->p(state);
+    return solver->p(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return specific entropy of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_specificEntropy_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_specificEntropy_C_impl(void *state,
 									   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->s(state);
+    return solver->s(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return derivative of density wrt pressure and specific enthalpy of specified medium
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_density_ph_der_C_impl(ExternalThermodynamicState *state,
+double TwoPhaseMedium_density_ph_der_C_impl(void *state,
 									  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->d_der(state);
+    return solver->d_der(static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Return the enthalpy at pressure p after an isentropic transformation from the specified medium state
@@ -332,62 +332,62 @@ double TwoPhaseMedium_isentropicEnthalpy_C_impl(double p_downstream, ExternalThe
 /*!
   This function computes the saturation properties for the specified inputs.
   @param p Pressure
-  @param ExternalSaturationProperties Pointer to return values for ExternalSaturationProperties struct
+  @param sat Pointer to return values for ExternalSaturationProperties struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setSat_p_C_impl(double p, ExternalSaturationProperties *sat,
+void TwoPhaseMedium_setSat_p_C_impl(double p, void *sat,
 							  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setSat_p(p, sat);
+    solver->setSat_p(p, static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Compute saturation properties from T
 /*!
   This function computes the saturation properties for the specified inputs.
   @param T Temperature
-  @param ExternalSaturationProperties Pointer to return values for ExternalSaturationProperties struct
+  @param sat Pointer to return values for ExternalSaturationProperties struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setSat_T_C_impl(double T, ExternalSaturationProperties *sat,
+void TwoPhaseMedium_setSat_T_C_impl(double T, void *sat,
 							  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setSat_T(T, sat);
+    solver->setSat_T(T, static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Compute bubble state
 /*!
   This function computes the  bubble state for the specified medium.
-  @param ExternalSaturationProperties Pointer to values of ExternalSaturationProperties struct
+  @param sat Pointer to values of ExternalSaturationProperties struct
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setBubbleState_C_impl(ExternalSaturationProperties *sat, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setBubbleState_C_impl(void *sat, int phase, void *state,
 									const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setBubbleState(sat, phase, state);
+    solver->setBubbleState(static_cast<ExternalSaturationProperties*>(sat), phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute dew state
 /*!
   This function computes the dew state for the specified medium.
-  @param ExternalSaturationProperties Pointer to values of ExternalSaturationProperties struct
+  @param sat Pointer to values of ExternalSaturationProperties struct
   @param phase Phase (2 for two-phase, 1 for one-phase, 0 if not known)
-  @param ExternalThermodynamicState Pointer to return values for ExternalThermodynamicState struct
+  @param state Pointer to return values for ExternalThermodynamicState struct
   @param mediumName Medium name
   @param libraryName Library name
   @param substanceName Substance name
 */
-void TwoPhaseMedium_setDewState_C_impl(ExternalSaturationProperties *sat, int phase, ExternalThermodynamicState *state,
+void TwoPhaseMedium_setDewState_C_impl(void *sat, int phase, void *state,
 								 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    solver->setDewState(sat, phase, state);
+    solver->setDewState(static_cast<ExternalSaturationProperties*>(sat), phase, static_cast<ExternalThermodynamicState*>(state));
 }
 
 //! Compute saturation temperature for specified medium and pressure
@@ -410,90 +410,90 @@ double TwoPhaseMedium_saturationTemperature_derp_C_impl(double p, const char *me
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_saturationTemperature_derp_sat_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_saturationTemperature_derp_sat_C_impl(void *sat,
 													  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->dTp(sat);
+    return solver->dTp(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return derivative of bubble density wrt pressure of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dBubbleDensity_dPressure_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dBubbleDensity_dPressure_C_impl(void *sat,
 												const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->ddldp(sat);
+    return solver->ddldp(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return derivative of dew density wrt pressure of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dDewDensity_dPressure_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dDewDensity_dPressure_C_impl(void *sat,
 											 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->ddvdp(sat);
+    return solver->ddvdp(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return derivative of bubble specific enthalpy wrt pressure of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dBubbleEnthalpy_dPressure_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dBubbleEnthalpy_dPressure_C_impl(void *sat,
 												 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->dhldp(sat);
+    return solver->dhldp(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return derivative of dew specific enthalpy wrt pressure of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dDewEnthalpy_dPressure_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dDewEnthalpy_dPressure_C_impl(void *sat,
 											  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->dhvdp(sat);
+    return solver->dhvdp(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return bubble density of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_bubbleDensity_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_bubbleDensity_C_impl(void *sat,
 									 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->dl(sat);
+    return solver->dl(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return dew density of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dewDensity_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dewDensity_C_impl(void *sat,
 								  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->dv(sat);
+    return solver->dv(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return bubble specific enthalpy of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_bubbleEnthalpy_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_bubbleEnthalpy_C_impl(void *sat,
 									  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->hl(sat);
+    return solver->hl(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return dew specific enthalpy of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dewEnthalpy_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dewEnthalpy_C_impl(void *sat,
 								   const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->hv(sat);
+    return solver->hv(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Compute saturation pressure for specified medium and temperature
@@ -511,30 +511,30 @@ double TwoPhaseMedium_saturationPressure_C_impl(double T, const char *mediumName
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_surfaceTension_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_surfaceTension_C_impl(void *sat,
 									  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->sigma(sat);
+    return solver->sigma(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return bubble specific entropy of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_bubbleEntropy_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_bubbleEntropy_C_impl(void *sat,
 									 const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->sl(sat);
+    return solver->sl(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 //! Return dew specific entropy of specified medium from saturation properties
 /*! Note: This function is not used by the default implementation of ExternalTwoPhaseMedium class.
     It might be used by external medium models customized solvers redeclaring the default functions
 */
-double TwoPhaseMedium_dewEntropy_C_impl(ExternalSaturationProperties *sat,
+double TwoPhaseMedium_dewEntropy_C_impl(void *sat,
 								  const char *mediumName, const char *libraryName, const char *substanceName){
 	BaseSolver *solver = SolverMap::getSolver(mediumName, libraryName, substanceName);
-    return solver->sv(sat);
+    return solver->sv(static_cast<ExternalSaturationProperties*>(sat));
 }
 
 // The following functions implement a workaround to handle ModelicaError and ModelicaWarning on Windows
@@ -544,7 +544,7 @@ double TwoPhaseMedium_dewEntropy_C_impl(ExternalSaturationProperties *sat,
 // set global pointers for ModelicaError and ModelicaWarning. 
 // These pointers are used by the errorMessage and warningMessage function when compiling for Windows
 
-void TwoPhaseMedium_setState_ph_C_impl_err(double p, double h, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
+void TwoPhaseMedium_setState_ph_C_impl_err(double p, double h, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
 {
     // Assign the global pointers to the function parameters, so they are initialized for all other functions
     #ifdef WIN32
@@ -552,10 +552,10 @@ void TwoPhaseMedium_setState_ph_C_impl_err(double p, double h, int phase, Extern
     ::ModelicaWarningPtr = ModelicaWarningPtr;
     #endif
     // Call the actual C implementation function
-    TwoPhaseMedium_setState_ph_C_impl(p, h, phase, state, mediumName, libraryName, substanceName);
+    TwoPhaseMedium_setState_ph_C_impl(p, h, phase, static_cast<ExternalThermodynamicState*>(state), mediumName, libraryName, substanceName);
 }
 
-void TwoPhaseMedium_setState_pT_C_impl_err(double p, double T, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
+void TwoPhaseMedium_setState_pT_C_impl_err(double p, double T, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
 {
     // Assign the global pointers to the function parameters, so they are initialized for all other functions
     #ifdef WIN32
@@ -563,10 +563,10 @@ void TwoPhaseMedium_setState_pT_C_impl_err(double p, double T, ExternalThermodyn
     ::ModelicaWarningPtr = ModelicaWarningPtr;
     #endif
     // Call the actual C implementation function
-    TwoPhaseMedium_setState_pT_C_impl(p, T, state, mediumName, libraryName, substanceName);
+    TwoPhaseMedium_setState_pT_C_impl(p, T, static_cast<ExternalThermodynamicState*>(state), mediumName, libraryName, substanceName);
 }
 
-void TwoPhaseMedium_setState_dT_C_impl_err(double d, double T, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
+void TwoPhaseMedium_setState_dT_C_impl_err(double d, double T, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
 {
     // Assign the global pointers to the function parameters, so they are initialized for all other functions
     #ifdef WIN32
@@ -574,10 +574,10 @@ void TwoPhaseMedium_setState_dT_C_impl_err(double d, double T, int phase, Extern
     ::ModelicaWarningPtr = ModelicaWarningPtr;
     #endif
     // Call the actual C implementation function
-    TwoPhaseMedium_setState_dT_C_impl(d, T, phase, state, mediumName, libraryName, substanceName);
+    TwoPhaseMedium_setState_dT_C_impl(d, T, phase, static_cast<ExternalThermodynamicState*>(state), mediumName, libraryName, substanceName);
 }
 
-void TwoPhaseMedium_setState_ps_C_impl_err(double p, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
+void TwoPhaseMedium_setState_ps_C_impl_err(double p, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
 {
     // Assign the global pointers to the function parameters, so they are initialized for all other functions
     #ifdef WIN32
@@ -585,10 +585,10 @@ void TwoPhaseMedium_setState_ps_C_impl_err(double p, double s, int phase, Extern
     ::ModelicaWarningPtr = ModelicaWarningPtr;
     #endif
     // Call the actual C implementation function
-    TwoPhaseMedium_setState_ps_C_impl(p, s, phase, state, mediumName, libraryName, substanceName);
+    TwoPhaseMedium_setState_ps_C_impl(p, s, phase, static_cast<ExternalThermodynamicState*>(state), mediumName, libraryName, substanceName);
 }
 
-void TwoPhaseMedium_setState_hs_C_impl_err(double h, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
+void TwoPhaseMedium_setState_hs_C_impl_err(double h, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *))
 {
     // Assign the global pointers to the function parameters, so they are initialized for all other functions
     #ifdef WIN32
@@ -596,5 +596,5 @@ void TwoPhaseMedium_setState_hs_C_impl_err(double h, double s, int phase, Extern
     ::ModelicaWarningPtr = ModelicaWarningPtr;
     #endif
     // Call the actual C implementation function
-    TwoPhaseMedium_setState_hs_C_impl(h, s, phase, state, mediumName, libraryName, substanceName);
+    TwoPhaseMedium_setState_hs_C_impl(h, s, phase, static_cast<ExternalThermodynamicState*>(state), mediumName, libraryName, substanceName);
 }

--- a/Projects/Sources/externalmedialib.h
+++ b/Projects/Sources/externalmedialib.h
@@ -68,6 +68,9 @@ Portable definitions of the EXPORT macro
   The ExternalThermodynamicState propery struct defines all the properties that
   are computed by external Modelica medium models extending from
   PartialExternalTwoPhaseMedium.
+  Note: the exported interface functions
+  use typeless void *state instead of ExternalThermodynamicState *state
+  as Modelica does not treat external struct types so far.
 */
 
 typedef struct ExternalThermodynamicState {
@@ -118,6 +121,9 @@ typedef struct ExternalThermodynamicState {
   The ExternalSaturationProperties propery struct defines all the saturation properties
   for the dew and the bubble line that are computed by external Modelica medium models
   extending from PartialExternalTwoPhaseMedium.
+  Note: the exported interface functions
+  use typeless void *sat instead of ExternalSaturationProperties *sat
+  as Modelica does not treat external struct types so far.
 */
 
 typedef struct ExternalSaturationProperties {
@@ -170,60 +176,60 @@ extern "C" {
 	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_getCriticalPressure_C_impl(const char *mediumName, const char *libraryName, const char *substanceName);
 	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_getCriticalMolarVolume_C_impl(const char *mediumName, const char *libraryName, const char *substanceName);
 
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ph_C_impl(double p, double h, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_pT_C_impl(double p, double T,            ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_dT_C_impl(double d, double T, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ps_C_impl(double p, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_hs_C_impl(double h, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ph_C_impl(double p, double h, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_pT_C_impl(double p, double T,            void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_dT_C_impl(double d, double T, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ps_C_impl(double p, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_hs_C_impl(double h, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
 
 	// These functions implement a workaround to handle ModelicaError and ModelicaWarning on Windows until a proper solution based on exporting symbols becomes available in Modelica tools
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ph_C_impl_err(double p, double h, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_pT_C_impl_err(double p, double T,            ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_dT_C_impl_err(double d, double T, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ps_C_impl_err(double p, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_hs_C_impl_err(double h, double s, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ph_C_impl_err(double p, double h, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_pT_C_impl_err(double p, double T,            void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_dT_C_impl_err(double d, double T, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_ps_C_impl_err(double p, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setState_hs_C_impl_err(double h, double s, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName, void (*ModelicaErrorPtr)(const char *), void (*ModelicaWarningPtr)(const char *));
 
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_partialDeriv_state_C_impl(const char *of, const char *wrt, const char *cst, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_partialDeriv_state_C_impl(const char *of, const char *wrt, const char *cst, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
 
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_prandtlNumber_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_temperature_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_velocityOfSound_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isobaricExpansionCoefficient_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificHeatCapacityCp_C_impl(ExternalThermodynamicState *state,	const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificHeatCapacityCv_C_impl(ExternalThermodynamicState *state,	const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_derh_p_C_impl(ExternalThermodynamicState *state,	const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_derp_h_C_impl(ExternalThermodynamicState *state,	const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dynamicViscosity_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificEnthalpy_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isothermalCompressibility_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_thermalConductivity_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_pressure_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificEntropy_C_impl(ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_ph_der_C_impl(ExternalThermodynamicState *state,	const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isentropicEnthalpy_C_impl(double p_downstream, ExternalThermodynamicState *refState,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_prandtlNumber_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_temperature_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_velocityOfSound_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isobaricExpansionCoefficient_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificHeatCapacityCp_C_impl(void *state,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificHeatCapacityCv_C_impl(void *state,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_derh_p_C_impl(void *state,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_derp_h_C_impl(void *state,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dynamicViscosity_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificEnthalpy_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isothermalCompressibility_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_thermalConductivity_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_pressure_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_specificEntropy_C_impl(void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_density_ph_der_C_impl(void *state,	const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_isentropicEnthalpy_C_impl(double p_downstream, void *refState,	const char *mediumName, const char *libraryName, const char *substanceName);
 
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setSat_p_C_impl(double p, ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setSat_T_C_impl(double T, ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setBubbleState_C_impl(ExternalSaturationProperties *sat, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setDewState_C_impl(ExternalSaturationProperties *sat, int phase, ExternalThermodynamicState *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setSat_p_C_impl(double p, void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setSat_T_C_impl(double T, void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setBubbleState_C_impl(void *sat, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT void TwoPhaseMedium_setDewState_C_impl(void *sat, int phase, void *state, const char *mediumName, const char *libraryName, const char *substanceName);
 
 	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_saturationTemperature_C_impl(double p, const char *mediumName, const char *libraryName, const char *substanceName);
 	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_saturationTemperature_derp_C_impl(double p, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_saturationTemperature_derp_sat_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_saturationTemperature_derp_sat_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
 
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dBubbleDensity_dPressure_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dDewDensity_dPressure_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dBubbleEnthalpy_dPressure_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dDewEnthalpy_dPressure_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleDensity_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewDensity_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleEnthalpy_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewEnthalpy_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dBubbleDensity_dPressure_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dDewDensity_dPressure_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dBubbleEnthalpy_dPressure_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dDewEnthalpy_dPressure_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleDensity_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewDensity_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleEnthalpy_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewEnthalpy_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
 	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_saturationPressure_C_impl(double T, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_surfaceTension_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleEntropy_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
-	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewEntropy_C_impl(ExternalSaturationProperties *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_surfaceTension_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_bubbleEntropy_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
+	EXTERNALMEDIA_EXPORT double TwoPhaseMedium_dewEntropy_C_impl(void *sat, const char *mediumName, const char *libraryName, const char *substanceName);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Modelica does not treat struct types in external function calls. Typeless void* prevent compiler warnings in C and errors in C++ due to incompatible pointer types.