### PR TITLE
R134a example medium

### DIFF
--- a/Modelica/ExternalMedia/Examples.mo
+++ b/Modelica/ExternalMedia/Examples.mo
@@ -58,6 +58,14 @@ package Examples "Examples of external medium model definitions"
       SpecificEnthalpy(start=2e5));
   end CO2CoolPropTabular;
 
+  package R134aCoolProp "CoolProp model of R134a"
+    extends ExternalMedia.Media.CoolPropMedium(
+      mediumName = "R-134a",
+      substanceNames = {"R134a"},
+      ThermoStates = Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
+      SpecificEnthalpy(start=2e5));
+  end R134aCoolProp;
+
   package R134aCoolPropTabular "CoolProp model of R134a using tabulated data and bicubic interpolation"
     extends ExternalMedia.Media.CoolPropMedium(
       mediumName = "R-134a",

--- a/Modelica/ExternalMedia/Examples.mo
+++ b/Modelica/ExternalMedia/Examples.mo
@@ -58,6 +58,14 @@ package Examples "Examples of external medium model definitions"
       SpecificEnthalpy(start=2e5));
   end CO2CoolPropTabular;
 
+  package R134aCoolPropTabular "CoolProp model of R134a using tabulated data and bicubic interpolation"
+    extends ExternalMedia.Media.CoolPropMedium(
+      mediumName = "R-134a",
+      substanceNames = {"R134a|enable_BICUBIC=1"},
+      ThermoStates = Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
+      SpecificEnthalpy(start=2e5));
+  end R134aCoolPropTabular;
+
   package WaterCoolProp "CoolProp model of water"
     extends ExternalMedia.Media.CoolPropMedium(
       mediumName = "Water",

--- a/Modelica/ExternalMedia/Examples.mo
+++ b/Modelica/ExternalMedia/Examples.mo
@@ -66,13 +66,21 @@ package Examples "Examples of external medium model definitions"
       SpecificEnthalpy(start=2e5));
   end R134aCoolProp;
 
-  package R134aCoolPropTabular "CoolProp model of R134a using tabulated data and bicubic interpolation"
+  package R134aCoolPropBicubic "CoolProp model of R134a using tabulated data and bicubic interpolation"
     extends ExternalMedia.Media.CoolPropMedium(
       mediumName = "R-134a",
       substanceNames = {"R134a|enable_BICUBIC=1"},
       ThermoStates = Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
       SpecificEnthalpy(start=2e5));
-  end R134aCoolPropTabular;
+  end R134aCoolPropBicubic;
+
+  package R134aCoolPropTaylor "CoolProp model of R134a using tabulated data and TTSE interpolation"
+    extends ExternalMedia.Media.CoolPropMedium(
+      mediumName = "R-134a",
+      substanceNames = {"R134a|enable_BICUBIC=1"},
+      ThermoStates = Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
+      SpecificEnthalpy(start=2e5));
+  end R134aCoolPropTaylor;
 
   package WaterCoolProp "CoolProp model of water"
     extends ExternalMedia.Media.CoolPropMedium(

--- a/Modelica/ExternalMedia/Examples.mo
+++ b/Modelica/ExternalMedia/Examples.mo
@@ -77,7 +77,7 @@ package Examples "Examples of external medium model definitions"
   package R134aCoolPropTaylor "CoolProp model of R134a using tabulated data and TTSE interpolation"
     extends ExternalMedia.Media.CoolPropMedium(
       mediumName = "R-134a",
-      substanceNames = {"R134a|enable_BICUBIC=1"},
+      substanceNames = {"R134a|enable_TTSE=1"},
       ThermoStates = Modelica.Media.Interfaces.Choices.IndependentVariables.ph,
       SpecificEnthalpy(start=2e5));
   end R134aCoolPropTaylor;


### PR DESCRIPTION
it might be nice to add R134a as predefined medium, because it also exists in MSL so it can be used for comparison and benchmarking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added three new example packages for modeling refrigerant R-134a with CoolProp, including standard, bicubic interpolation, and TTSE interpolation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->